### PR TITLE
README updates and misc changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "thruster", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
-  gem 'dotenv-rails', require: 'dotenv/load'
+  gem "dotenv-rails", require: "dotenv/load"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
@@ -62,4 +62,4 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
-gem 'pg', '~> 1.1'
+gem "pg", "~> 1.1"

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The application uses four main models with the following relationships:
 **Model Generation Commands Used:**
 
 ```bash
-rails generate model Restaurant name:string street_address:string city:string state:string zip:string latitude:decimal longitude:decimal phone:string website:string yelp_id:string
+bin/rails generate model Restaurant name:string street_address:string city:string state:string zip:string latitude:decimal longitude:decimal phone:string website:string yelp_id:string
 
-rails generate model Taco restaurant:references name:string description:text price_cents:integer calories:integer tortilla_type:string protein_type:string is_vegan:boolean is_bulk:boolean is_daily_special:boolean available_from:time available_to:time
+bin/rails generate model Taco restaurant:references name:string description:text price_cents:integer calories:integer tortilla_type:string protein_type:string is_vegan:boolean is_bulk:boolean is_daily_special:boolean available_from:time available_to:time
 
-rails generate model Photo taco:references user_id:uuid url:string is_user_uploaded:boolean
+bin/rails generate model Photo taco:references user_id:uuid url:string is_user_uploaded:boolean
 
-rails generate model Review restaurant:references author_name:string author_url:string google_rating:integer review_text:text review_time:bigint relative_time_description:string language:string review_date:datetime content:text
+bin/rails generate model Review restaurant:references author_name:string author_url:string google_rating:integer review_text:text review_time:bigint relative_time_description:string language:string review_date:datetime content:text
 ```
 
 ---
@@ -189,18 +189,18 @@ volumes:
 Setup the database:
 
 ```bash
-rails db:migrate
-rails db:seed
+bin/rails db:migrate
+bin/rails db:seed
 ```
 
-> ⚠️ Do **not** run `rails db:create` — Docker handles database creation.
+> ⚠️ Do **not** run `bin/rails db:create` — Docker handles database creation.
 
 ---
 
 ### 5. Start the Development Server
 
 ```bash
-rails server
+bin/rails server
 ```
 
 Visit `http://localhost:3000`
@@ -227,9 +227,9 @@ Visit `http://localhost:3000`
 Start the Rails console:
 
 ```bash
-rails console
+bin/rails console
 # or
-rails c
+bin/rails c
 ```
 
 Examples:
@@ -257,14 +257,14 @@ exit
 ### Running Tests
 
 ```bash
-rails test
+bin/rails test
 ```
 
 ### Code Quality
 
 ```bash
-bundle exec rubocop
-bundle exec brakeman
+bin/rubocop
+bin/brakeman
 ```
 
 ### Background Jobs
@@ -292,7 +292,7 @@ Python scripts are located in `/data_collection`.
 - **540 photos**
 - **765 reviews**
 
-> The data collection module is for maintainers. Other devs can use `rails db:seed`.
+> The data collection module is for maintainers. Other devs can use `bin/rails db:seed`.
 
 ---
 
@@ -373,7 +373,7 @@ Recent changes:
 4. Run tests and quality tools:
 
 ```bash
-rails test && bundle exec rubocop
+bin/rails test && bin/rubocop
 ```
 
 5. Submit a PR
@@ -385,9 +385,9 @@ rails test && bundle exec rubocop
 ```bash
 cd data_collection && docker-compose up -d && cd ..
 bundle install
-rails db:migrate && rails db:seed
-rails server
-rails test
+bin/rails db:migrate && bin/rails db:seed
+bin/rails server
+bin/rails test
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ docker-compose up -d
 cd ..
 ```
 
+> NOTE: You can also start/stop the PostgreSQL container using `bin/db [up|down]`
+
 **`data_collection/docker-compose.yml`:**
 
 ```yaml

--- a/bin/db
+++ b/bin/db
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+if ARGV.length != 1 || !%w[up down].include?(ARGV[0])
+  puts "Usage: db [up|down]"
+  exit 1
+end
+
+case ARGV[0]
+when 'up'
+  puts "Starting development database in the background..."
+  exec "docker-compose -f data_collection/docker-compose.yml up -d "
+when 'down'
+  puts "Stopping development database..."
+  exec "docker-compose -f data_collection/docker-compose.yml down"
+else
+  puts "Invalid argument. Use 'up' or 'down'."
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # Taco Price Index - Seed Data
 # Real San Antonio taco data for development
 
@@ -25631,12 +25632,12 @@ if defined?(Review)
     "restaurant_id": "fecdd804-e74f-4e8b-8575-0d904fd855cb"
   }
 ]
-  
+
   reviews_data.each do |attrs|
     attrs['review_date'] = DateTime.parse(attrs['review_date']) if attrs['review_date']
     Review.create!(attrs.except('created_at', 'updated_at'))
   end
-  
+
   puts "✅ Created #{Review.count} reviews"
 else
   puts "⚠️  Review model not found, skipping reviews"


### PR DESCRIPTION
## Summary

In this pull request we're updating the README with the following changes:

- Changed `rails` commands to `bin/rails` to ensure the project version of rails is used
- Changed `bundle exec rubocop` and `bundle exec brakeman` commands to `bin/rubocop` and `bin/brakeman` to use binstubs

The following misc changes have also been added:

- Fixed `rubocop` linter errors
- Added a `bin/db` script to easily start/stop the development database