### PR TITLE
Feat: Show Favorited Restaurants and Accurate Favorite Count

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,7 +5,16 @@ class FavoritesController < ApplicationController
     restaurant = Restaurant.find(params[:restaurant_id])
     current_user.toggle_favorite(restaurant)
 
+    restaurant.reload
+
     respond_to do |format|
+      format.json do
+        render json: {
+          favorite_count: restaurant.favorite_count,
+          is_favorited: current_user.favorite?(restaurant) # The new favorite status
+        }
+      end
+
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.update(

--- a/app/javascript/controllers/favorite_controller.js
+++ b/app/javascript/controllers/favorite_controller.js
@@ -1,10 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["count", "icon", "text", "button"]
+
   toggle(event) {
     event.preventDefault()
-    const button = event.currentTarget
-    const restaurantId = button.dataset.restaurantId
+    const button = this.buttonTarget;
+    const restaurantId = this.element.dataset.restaurantId;
+
+    if (!restaurantId) {
+      console.error("Restaurant ID is missing on the button's dataset.");
+      return; // Stop execution if ID is missing
+    }
 
     fetch(`/restaurants/${restaurantId}/toggle_favorite`, {
       method: 'POST',
@@ -25,12 +32,22 @@ export default class extends Controller {
     })
     .then(data => {
       if (!data) return // Skip if we were redirected
-      
-      const isFavorited = button.classList.toggle('favorited')
-      button.innerHTML = isFavorited ? 'Unfavorite' : 'Favorite'
-      const countElement = this.element.querySelector(`[data-restaurant-id="${restaurantId}"] .favorite-count`)
-      if (countElement) {
-        countElement.textContent = data.favorite_count
+
+      if(data.is_favorite) {
+        button.classList.remove('btn-outline-danger'); 
+        button.classList.add('btn-danger');
+      } else {
+        button.classList.remove('btn-danger');
+        button.classList.add('btn-outline-danger');
+      }
+
+      button.innerHTML = data.is_favorite ? 'Unfavorite' : 'Favorite';
+      const countElement = button.nextElementSibling;
+
+      if (countElement && countElement.matches('[data-favorite-target="count"]')) {
+        countElement.textContent = data.favorite_count;
+      } else {
+        console.warn('Favorite count element not found as immediate next sibling with data-favorite-target="count".');
       }
     })
     .catch(error => console.error('Error:', error))

--- a/app/models/user_favorite.rb
+++ b/app/models/user_favorite.rb
@@ -3,18 +3,4 @@ class UserFavorite < ApplicationRecord
   belongs_to :restaurant, counter_cache: :user_favorites_count
 
   validates :user_id, uniqueness: { scope: :restaurant_id }
-
-  # Update the counter cache when a favorite is created or destroyed
-  after_create :increment_counter_cache
-  after_destroy :decrement_counter_cache
-
-  private
-
-  def increment_counter_cache
-    Restaurant.increment_counter(:user_favorites_count, restaurant_id)
-  end
-
-  def decrement_counter_cache
-    Restaurant.decrement_counter(:user_favorites_count, restaurant_id)
-  end
 end

--- a/app/views/frontend_pages/_favorite_button.html.erb
+++ b/app/views/frontend_pages/_favorite_button.html.erb
@@ -1,10 +1,11 @@
 <% if authenticated? %>
-  <button class="btn btn-sm <%= @is_favorited ? 'btn-danger' : 'btn-outline-danger' %>" 
+<% is_favorited = Current.session&.user.favorite?(restaurant) %> 
+<button class="btn btn-sm <%= is_favorited ? 'btn-danger' : 'btn-outline-danger' %>" 
           data-controller="favorite"
           data-action="click->favorite#toggle"
           data-favorite-target="button"
           data-restaurant-id="<%= restaurant.id %>">
-    <%= @is_favorited ? 'Unfavorite' : 'Favorite' %>
+    <%= is_favorited ? 'Unfavorite' : 'Favorite' %>
   </button>
 <% else %>
   <button class="btn btn-sm btn-outline-danger" 


### PR DESCRIPTION
Now, favorited restaurants and favorite count will show on the frontend after a reload. Also, favorite button will update as will the favorite count when a restaurant is favorited.

Fixed an issue in `user_favorite.rb` that caused doubling of the favorite count. 

Modified the following files:
- `favorites_controller.rb`
- `favorite_controller.js`
- `_favorite_button.html.erb`
- `user_favorite.rb`

Fixes [35](https://github.com/Alamo-Tech-Collective/Taco-Price-Index/issues/35)
