### PR TITLE
Revamp the map page styles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       msgpack (~> 1.2)
     bootstrap (5.3.5)
       popper_js (>= 2.11.8, < 3)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     cable_ready (5.0.6)

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -617,6 +617,233 @@ body.bg-cream {
   border-radius: 8px;
 }
 
+/* Enhanced Restaurant Cards */
+.restaurant-cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 20px;
+  padding: 20px;
+}
+
+.restaurant-card {
+  background-color: #ffffff;
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+
+.restaurant-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+
+/* Card Header */
+.restaurant-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 15px;
+  border-bottom: 2px solid #f0f0f0;
+  padding-bottom: 10px;
+}
+
+.restaurant-name {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #5c4430;
+  margin: 0;
+  flex: 1;
+  margin-right: 10px;
+}
+
+/* Status Indicator */
+.status-indicator {
+  display: flex;
+  align-items: center;
+}
+
+.status-badge {
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.status-open {
+  background-color: #28a745;
+  color: white;
+  box-shadow: 0 2px 5px rgba(40, 167, 69, 0.3);
+}
+
+.status-closed {
+  background-color: #dc3545;
+  color: white;
+  box-shadow: 0 2px 5px rgba(220, 53, 69, 0.3);
+}
+
+/* Card Body */
+.restaurant-card-body {
+  margin-bottom: 20px;
+}
+
+.restaurant-detail {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  padding: 5px 0;
+}
+
+.detail-label {
+  font-weight: 600;
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
+.cuisine-type {
+  color: #a65347;
+  font-weight: 600;
+  background-color: rgba(166, 83, 71, 0.1);
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+}
+
+.location-info {
+  color: #364c3f;
+  font-weight: 500;
+}
+
+.rating-display {
+  color: #ffd700;
+  font-weight: bold;
+}
+
+.price-info {
+  color: #5c4430;
+  font-weight: 600;
+}
+
+/* Action Buttons */
+.restaurant-card-actions {
+  border-top: 1px solid #f0f0f0;
+  padding-top: 15px;
+}
+
+.action-buttons {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.pin-btn {
+  background-color: #364c3f;
+  color: white;
+}
+
+.pin-btn:hover {
+  background-color: #2a3a30;
+  transform: scale(1.05);
+}
+
+.info-btn {
+  background-color: #a65347;
+  color: white;
+}
+
+.info-btn:hover {
+  background-color: #94493e;
+  color: white;
+  text-decoration: none;
+  transform: scale(1.05);
+}
+
+.favorite-section {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* Responsive Design for Cards */
+@media (max-width: 768px) {
+  .restaurant-cards-container {
+    grid-template-columns: 1fr;
+    padding: 15px;
+    gap: 15px;
+  }
+  
+  .restaurant-card {
+    padding: 15px;
+  }
+  
+  .restaurant-name {
+    font-size: 1.3rem;
+  }
+  
+  .action-buttons {
+    flex-direction: column;
+    gap: 8px;
+  }
+  
+  .action-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .restaurant-card-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  
+  .status-indicator {
+    width: 100%;
+  }
+  
+  .restaurant-detail {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 3px;
+  }
+}
+
+/* Restaurant List Section */
+.restaurant-list-section {
+  background-color: #f8f3eb;
+  padding: 30px 0;
+  margin-top: 20px;
+}
+
+.section-title {
+  font-size: 2rem;
+  font-weight: bold;
+  margin: 0;
+}
+
 /* Review form */
 body.bg-cream {
   background-color: #f8f3eb;

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -844,6 +844,299 @@ body.bg-cream {
   margin: 0;
 }
 
+/* Filter Bar */
+.filter-bar-container {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #f8f3eb;
+  border-bottom: 2px solid #a65347;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.filter-bar {
+  background: linear-gradient(135deg, #a65347 0%, #94493e 100%);
+  color: white;
+  padding: 15px 0;
+}
+
+.filter-group {
+  margin-bottom: 0;
+}
+
+.filter-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f8f3eb;
+  margin-bottom: 5px;
+  display: block;
+}
+
+/* Search Input */
+.search-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-input {
+  background-color: #f8f3eb;
+  border: 2px solid transparent;
+  color: #5c4430;
+  font-weight: 500;
+  padding: 8px 50px 8px 12px;
+  border-radius: 8px 0 0 8px;
+  transition: all 0.3s ease;
+  flex: 1;
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: #364c3f;
+  box-shadow: 0 0 0 3px rgba(54, 76, 63, 0.2);
+  background-color: white;
+}
+
+.search-btn, .clear-search-btn {
+  background-color: #364c3f;
+  color: white;
+  border: none;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  height: 42px;
+}
+
+.search-btn {
+  border-radius: 0 8px 8px 0;
+}
+
+.clear-search-btn {
+  background-color: #dc3545;
+  border-radius: 0;
+  margin-left: -1px;
+}
+
+.search-btn:hover {
+  background-color: #2a3a30;
+}
+
+.clear-search-btn:hover {
+  background-color: #c82333;
+}
+
+.search-btn i, .clear-search-btn i {
+  font-size: 0.9rem;
+}
+
+/* Select Dropdowns */
+.filter-select {
+  background-color: #f8f3eb;
+  border: 2px solid transparent;
+  color: #5c4430;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #364c3f;
+  box-shadow: 0 0 0 3px rgba(54, 76, 63, 0.2);
+  background-color: white;
+}
+
+/* Toggle Switch */
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.filter-toggle {
+  display: none;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  margin: 0;
+}
+
+.toggle-switch {
+  position: relative;
+  width: 50px;
+  height: 26px;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 13px;
+  margin-right: 8px;
+  transition: all 0.3s ease;
+}
+
+.toggle-switch::before {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.filter-toggle:checked + .toggle-label .toggle-switch {
+  background-color: #364c3f;
+}
+
+.filter-toggle:checked + .toggle-label .toggle-switch::before {
+  transform: translateX(24px);
+}
+
+.toggle-text {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #f8f3eb;
+}
+
+/* Filter Actions */
+.filter-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 15px;
+}
+
+.results-count {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f8f3eb;
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 8px 12px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.btn-clear {
+  background-color: #364c3f;
+  color: white;
+  border: none;
+  padding: 8px 15px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.btn-clear:hover {
+  background-color: #2a3a30;
+  transform: scale(1.05);
+}
+
+/* Tags */
+.tags-container {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex: 1;
+}
+
+.tag-button {
+  background-color: rgba(248, 243, 235, 0.15);
+  color: #f8f3eb;
+  border: 1px solid rgba(248, 243, 235, 0.3);
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.tag-button:hover {
+  background-color: rgba(248, 243, 235, 0.25);
+  border-color: rgba(248, 243, 235, 0.5);
+  transform: scale(1.05);
+}
+
+.tag-button.active {
+  background-color: #364c3f;
+  border-color: #364c3f;
+  color: white;
+}
+
+.tag-button.active:hover {
+  background-color: #2a3a30;
+}
+
+/* Responsive Design for Filter Bar */
+@media (max-width: 992px) {
+  .filter-bar {
+    padding: 12px 0;
+  }
+  
+  .filter-actions {
+    justify-content: center;
+    margin-top: 10px;
+  }
+}
+
+@media (max-width: 768px) {
+  .filter-bar-container {
+    position: relative;
+  }
+  
+  .tags-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  
+  .tags-list {
+    width: 100%;
+  }
+  
+  .filter-actions {
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+@media (max-width: 576px) {
+  .filter-bar {
+    padding: 10px 0;
+  }
+  
+  .toggle-container {
+    justify-content: center;
+  }
+  
+  .tag-button {
+    font-size: 0.75rem;
+    padding: 5px 10px;
+  }
+}
+
 /* Review form */
 body.bg-cream {
   background-color: #f8f3eb;

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -901,14 +901,18 @@ body.bg-cream {
   background-color: #364c3f;
   color: white;
   border: none;
-  padding: 10px 12px;
+  padding: 10px 15px;
   cursor: pointer;
   transition: all 0.3s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 40px;
+  gap: 6px;
+  min-width: 70px;
   height: 42px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .search-btn {
@@ -919,18 +923,25 @@ body.bg-cream {
   background-color: #dc3545;
   border-radius: 0;
   margin-left: -1px;
+  min-width: 60px;
 }
 
 .search-btn:hover {
   background-color: #2a3a30;
+  transform: scale(1.02);
 }
 
 .clear-search-btn:hover {
   background-color: #c82333;
+  transform: scale(1.02);
 }
 
 .search-btn i, .clear-search-btn i {
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+}
+
+.search-btn span, .clear-search-btn span {
+  font-size: 0.8rem;
 }
 
 /* Select Dropdowns */

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -919,7 +919,8 @@ body.bg-cream {
   border-radius: 0 8px 8px 0;
 }
 
-.clear-search-btn {
+.clear-search-btn,
+.btn.clear-search-btn {
   background-color: #dc3545;
   border-radius: 0;
   margin-left: -1px;
@@ -934,6 +935,15 @@ body.bg-cream {
 .clear-search-btn:hover {
   background-color: #c82333;
   transform: scale(1.02);
+}
+
+#clearFilters {
+    color: white;
+}
+
+#clearFilters:hover {
+    background-color: #c82333;
+    transform: scale(1.02);
 }
 
 .search-btn i, .clear-search-btn i {

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -401,6 +401,10 @@ body.bg-cream {
 .map-section {
   background-color: #a65347;
   border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  /* align-items: center; */
+  justify-content: center;
 }
 
 .search-bar {

--- a/app/assets/stylesheets/frontend.css
+++ b/app/assets/stylesheets/frontend.css
@@ -421,7 +421,7 @@ body.bg-cream {
   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-.btn-filter {
+.btn-filter.filter-button { /* needed to override bootstrap button styles */
   background-color: #364c3f;
   color: white;
   font-weight: bold;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "frontend"
+import "restaurant_filters"

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -346,6 +346,47 @@ export default class extends Controller {
     }
   }
   
+  // Function to pin a specific restaurant on the map
+  pinRestaurantOnMap(restaurantId, lat, lng) {
+    if (!this.map) {
+      debug('Cannot pin restaurant: map not initialized');
+      return;
+    }
+    
+    try {
+      debug(`Pinning restaurant ${restaurantId} at ${lat}, ${lng}`);
+      
+      // Center map on the restaurant
+      const position = { lat: parseFloat(lat), lng: parseFloat(lng) };
+      this.map.setCenter(position);
+      this.map.setZoom(16);
+      
+      // Add a highlighted marker
+      const marker = new google.maps.Marker({
+        position,
+        map: this.map,
+        title: 'Selected Restaurant',
+        animation: google.maps.Animation.BOUNCE,
+        icon: {
+          url: 'https://maps.google.com/mapfiles/ms/icons/red-dot.png',
+          scaledSize: new google.maps.Size(40, 40)
+        }
+      });
+      
+      // Stop bouncing after 2 seconds
+      setTimeout(() => {
+        if (marker) {
+          marker.setAnimation(null);
+        }
+      }, 2000);
+      
+      debug('Restaurant pinned successfully');
+      
+    } catch (error) {
+      console.error('Error pinning restaurant:', error);
+    }
+  }
+  
   disconnect() {
     // Clean up
     if (this.map) {

--- a/app/javascript/restaurant_filters.js
+++ b/app/javascript/restaurant_filters.js
@@ -158,7 +158,12 @@ class RestaurantFilters {
       // Get tags from data attributes
       const tags = JSON.parse(card.getAttribute('data-tags') || '[]');
       
-      console.log(`Loading restaurant: ${name}, Status: '${status}', isOpen: ${isOpen}, CSS classes: ${statusBadge?.className}`);
+      console.log(`Loading restaurant: ${name}`);
+      console.log(`  - Status text: '${status}'`);
+      console.log(`  - data-open attribute: '${isOpenFromData}'`);
+      console.log(`  - isOpen parsed: ${isOpen}`);
+      console.log(`  - CSS classes: ${statusBadge?.className}`);
+      console.log(`  - Distance: ${distance}`);
       
       return {
         element: card,
@@ -177,6 +182,9 @@ class RestaurantFilters {
   }
   
   filterRestaurants() {
+    console.log('\n=== FILTERING RESTAURANTS ===');
+    console.log('Active filters:', this.activeFilters);
+    
     this.filteredRestaurants = this.restaurants.filter(restaurant => {
       // Search filter - if there's search text, filter by it; if no matches, show none
       if (this.activeFilters.search && this.activeFilters.search.trim() !== '') {

--- a/app/javascript/restaurant_filters.js
+++ b/app/javascript/restaurant_filters.js
@@ -204,7 +204,10 @@ class RestaurantFilters {
       if (this.activeFilters.openNow) {
         console.log(`Checking ${restaurant.name}: isOpen = ${restaurant.isOpen}, status text = '${restaurant.statusText}'`);
         if (!restaurant.isOpen) {
+          console.log(`  -> FILTERED OUT: ${restaurant.name} because isOpen = false`);
           return false;
+        } else {
+          console.log(`  -> KEEPING: ${restaurant.name} because isOpen = true`);
         }
       }
       
@@ -235,19 +238,26 @@ class RestaurantFilters {
   }
   
   renderFilteredResults() {
-    // Hide all restaurants first
+    console.log(`Rendering results: ${this.filteredRestaurants.length} restaurants to show`);
+    
+    // Hide all restaurants first (synchronous)
     this.restaurants.forEach(restaurant => {
       restaurant.element.style.display = 'none';
       restaurant.visible = false;
     });
     
-    // Show filtered restaurants with animation
+    // Show filtered restaurants immediately, then add animation
     this.filteredRestaurants.forEach((restaurant, index) => {
+      // Show immediately
+      restaurant.element.style.display = 'block';
+      restaurant.visible = true;
+      
+      // Add staggered animation
       setTimeout(() => {
-        restaurant.element.style.display = 'block';
         restaurant.element.style.animation = 'fadeInUp 0.3s ease forwards';
-        restaurant.visible = true;
-      }, index * 50); // Stagger animation
+      }, index * 50);
+      
+      console.log(`  -> SHOWING: ${restaurant.name}`);
     });
     
     // Show \"no results\" message if needed
@@ -370,6 +380,22 @@ class RestaurantFilters {
       clearTimeout(timeout);
       timeout = setTimeout(later, wait);
     };
+  }
+  
+  // Debug helper function to check restaurant status
+  debugRestaurantStatus() {
+    console.log('=== RESTAURANT STATUS DEBUG ===');
+    this.restaurants.forEach(restaurant => {
+      const badge = restaurant.element.querySelector('.status-badge');
+      const badgeText = badge ? badge.textContent.trim() : 'No badge';
+      const badgeClass = badge ? badge.className : 'No class';
+      console.log(`${restaurant.name}:`);
+      console.log(`  - JavaScript isOpen: ${restaurant.isOpen}`);
+      console.log(`  - Badge text: "${badgeText}"`);
+      console.log(`  - Badge classes: ${badgeClass}`);
+      console.log(`  - data-open: ${restaurant.element.getAttribute('data-open')}`);
+      console.log('---');
+    });
   }
 }
 

--- a/app/javascript/restaurant_filters.js
+++ b/app/javascript/restaurant_filters.js
@@ -150,8 +150,16 @@ class RestaurantFilters {
       // Better open/closed detection using CSS class and text content
       let isOpen = false;
       if (statusBadge) {
-        isOpen = statusBadge.classList.contains('status-open') || 
-                 status.toLowerCase().includes('open now');
+        // Check CSS classes first (most reliable)
+        if (statusBadge.classList.contains('status-open')) {
+          isOpen = true;
+        } else if (statusBadge.classList.contains('status-closed')) {
+          isOpen = false;
+        } else {
+          // Fallback to text content
+          const statusText = status.toLowerCase().trim();
+          isOpen = statusText.includes('open now') || statusText === 'open';
+        }
       }
       
       // Extract distance if available (assumes format like \"2.5 mi - City\")

--- a/app/javascript/restaurant_filters.js
+++ b/app/javascript/restaurant_filters.js
@@ -252,9 +252,16 @@ class RestaurantFilters {
       restaurant.element.style.display = 'block';
       restaurant.visible = true;
       
-      // Add staggered animation
+      // Add staggered animation, then clear it to restore hover effects
       setTimeout(() => {
         restaurant.element.style.animation = 'fadeInUp 0.3s ease forwards';
+        
+        // Clear animation after it completes to restore hover effects
+        setTimeout(() => {
+          restaurant.element.style.animation = '';
+          restaurant.element.style.transform = '';
+          restaurant.element.style.opacity = '';
+        }, 300); // Animation duration
       }, index * 50);
       
       console.log(`  -> SHOWING: ${restaurant.name}`);

--- a/app/javascript/restaurant_filters.js
+++ b/app/javascript/restaurant_filters.js
@@ -1,0 +1,405 @@
+// Restaurant Filtering System
+class RestaurantFilters {
+  constructor() {
+    this.restaurants = [];
+    this.filteredRestaurants = [];
+    this.activeFilters = {
+      search: '',
+      cuisine: '',
+      openNow: false,
+      distance: '',
+      tags: []
+    };
+    
+    this.init();
+  }
+  
+  init() {
+    this.cacheElements();
+    this.bindEvents();
+    this.loadRestaurantData();
+    this.setupTags();
+  }
+  
+  cacheElements() {
+    // Filter elements
+    this.searchInput = document.getElementById('searchInput');
+    this.cuisineFilter = document.getElementById('cuisineFilter');
+    this.openNowToggle = document.getElementById('openNowToggle');
+    this.distanceFilter = document.getElementById('distanceFilter');
+    this.clearFiltersBtn = document.getElementById('clearFilters');
+    this.resultsCount = document.getElementById('resultsCount');
+    this.tagsList = document.getElementById('tagsList');
+    
+    // Restaurant cards container
+    this.restaurantContainer = document.querySelector('.restaurant-cards-container');
+  }
+  
+  bindEvents() {
+    // Search input - button-based search
+    if (this.searchInput) {
+      // Search on Enter key
+      this.searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          this.performSearch();
+        }
+      });
+      
+      // Show/hide clear button based on input
+      this.searchInput.addEventListener('input', (e) => {
+        const clearBtn = document.getElementById('clearSearchBtn');
+        if (clearBtn) {
+          clearBtn.style.display = e.target.value.trim() ? 'flex' : 'none';
+        }
+      });
+    }
+    
+    // Search button
+    const searchBtn = document.getElementById('searchBtn');
+    if (searchBtn) {
+      searchBtn.addEventListener('click', () => {
+        this.performSearch();
+      });
+    }
+    
+    // Clear search button
+    const clearSearchBtn = document.getElementById('clearSearchBtn');
+    if (clearSearchBtn) {
+      clearSearchBtn.addEventListener('click', () => {
+        this.clearSearch();
+      });
+    }
+    
+    // Cuisine dropdown
+    if (this.cuisineFilter) {
+      this.cuisineFilter.addEventListener('change', (e) => {
+        this.activeFilters.cuisine = e.target.value;
+        this.filterRestaurants();
+      });
+    }
+    
+    // Open now toggle
+    if (this.openNowToggle) {
+      this.openNowToggle.addEventListener('change', (e) => {
+        this.activeFilters.openNow = e.target.checked;
+        this.filterRestaurants();
+      });
+    }
+    
+    // Distance filter
+    if (this.distanceFilter) {
+      this.distanceFilter.addEventListener('change', (e) => {
+        this.activeFilters.distance = e.target.value;
+        this.filterRestaurants();
+      });
+    }
+    
+    // Clear filters
+    if (this.clearFiltersBtn) {
+      this.clearFiltersBtn.addEventListener('click', () => {
+        this.clearAllFilters();
+      });
+    }
+  }
+  
+  setupTags() {
+    if (!this.tagsList) return;
+    
+    const tagButtons = this.tagsList.querySelectorAll('.tag-button');
+    tagButtons.forEach(button => {
+      button.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.toggleTag(button);
+      });
+    });
+  }
+  
+  toggleTag(button) {
+    const tag = button.getAttribute('data-tag');
+    const isActive = button.classList.contains('active');
+    
+    if (isActive) {
+      // Remove tag
+      button.classList.remove('active');
+      const index = this.activeFilters.tags.indexOf(tag);
+      if (index > -1) {
+        this.activeFilters.tags.splice(index, 1);
+      }
+    } else {
+      // Add tag
+      button.classList.add('active');
+      if (!this.activeFilters.tags.includes(tag)) {
+        this.activeFilters.tags.push(tag);
+      }
+    }
+    
+    this.filterRestaurants();
+  }
+  
+  loadRestaurantData() {
+    // Load restaurant data from the DOM
+    const restaurantCards = document.querySelectorAll('.restaurant-card');
+    this.restaurants = Array.from(restaurantCards).map(card => {
+      const name = card.querySelector('.restaurant-name')?.textContent || '';
+      const cuisine = card.querySelector('.cuisine-type')?.textContent || '';
+      const statusBadge = card.querySelector('.status-badge');
+      const status = statusBadge?.textContent || '';
+      const location = card.querySelector('.location-info')?.textContent || '';
+      
+      // Better open/closed detection using CSS class and text content
+      let isOpen = false;
+      if (statusBadge) {
+        isOpen = statusBadge.classList.contains('status-open') || 
+                 status.toLowerCase().includes('open now');
+      }
+      
+      // Extract distance if available (assumes format like \"2.5 mi - City\")
+      let distance = null;
+      const locationMatch = location.match(/(\d+\.?\d*) mi/);
+      if (locationMatch) {
+        distance = parseFloat(locationMatch[1]);
+      }
+      
+      // Get tags from data attributes
+      const tags = JSON.parse(card.getAttribute('data-tags') || '[]');
+      
+      console.log(`Loading restaurant: ${name}, Status: '${status}', isOpen: ${isOpen}, CSS classes: ${statusBadge?.className}`);
+      
+      return {
+        element: card,
+        name: name.toLowerCase(),
+        cuisine: cuisine.toLowerCase(),
+        isOpen: isOpen,
+        statusText: status,
+        distance: distance,
+        tags: tags,
+        visible: true
+      };
+    });
+    
+    this.filteredRestaurants = [...this.restaurants];
+    this.updateResultsCount();
+  }
+  
+  filterRestaurants() {
+    this.filteredRestaurants = this.restaurants.filter(restaurant => {
+      // Search filter - only apply if there's search text, otherwise show all
+      if (this.activeFilters.search && this.activeFilters.search !== '') {
+        if (!restaurant.name.includes(this.activeFilters.search)) {
+          return false;
+        }
+      }
+      
+      // Cuisine filter
+      if (this.activeFilters.cuisine && 
+          restaurant.cuisine !== this.activeFilters.cuisine.toLowerCase()) {
+        return false;
+      }
+      
+      // Open now filter - more robust checking
+      if (this.activeFilters.openNow) {
+        console.log(`Checking ${restaurant.name}: isOpen = ${restaurant.isOpen}, status text = '${restaurant.statusText}'`);
+        if (!restaurant.isOpen) {
+          return false;
+        }
+      }
+      
+      // Distance filter
+      if (this.activeFilters.distance && restaurant.distance) {
+        const maxDistance = parseFloat(this.activeFilters.distance);
+        if (restaurant.distance > maxDistance) {
+          return false;
+        }
+      }
+      
+      // Tags filter
+      if (this.activeFilters.tags.length > 0) {
+        const hasAllTags = this.activeFilters.tags.every(tag => 
+          restaurant.tags.includes(tag)
+        );
+        if (!hasAllTags) {
+          return false;
+        }
+      }
+      
+      return true;
+    });
+    
+    this.renderFilteredResults();
+    this.updateResultsCount();
+  }
+  
+  renderFilteredResults() {
+    // Hide all restaurants first
+    this.restaurants.forEach(restaurant => {
+      restaurant.element.style.display = 'none';
+      restaurant.visible = false;
+    });
+    
+    // Show filtered restaurants with animation
+    this.filteredRestaurants.forEach((restaurant, index) => {
+      setTimeout(() => {
+        restaurant.element.style.display = 'block';
+        restaurant.element.style.animation = 'fadeInUp 0.3s ease forwards';
+        restaurant.visible = true;
+      }, index * 50); // Stagger animation
+    });
+    
+    // Show \"no results\" message if needed
+    this.showNoResultsMessage();
+  }
+  
+  showNoResultsMessage() {
+    let noResultsMsg = document.getElementById('noResultsMessage');
+    
+    if (this.filteredRestaurants.length === 0) {
+      if (!noResultsMsg) {
+        noResultsMsg = document.createElement('div');
+        noResultsMsg.id = 'noResultsMessage';
+        noResultsMsg.className = 'no-results-message';
+        noResultsMsg.innerHTML = `
+          <div class=\"text-center py-5\">
+            <i class=\"fas fa-search fa-3x text-muted mb-3\"></i>
+            <h4 class=\"text-muted\">No restaurants found</h4>
+            <p class=\"text-muted\">Try adjusting your filters or search terms</p>
+            <button class=\"btn btn-primary\" onclick=\"restaurantFilters.clearAllFilters()\">
+              Clear All Filters
+            </button>
+          </div>
+        `;
+        this.restaurantContainer.appendChild(noResultsMsg);
+      }
+      noResultsMsg.style.display = 'block';
+    } else {
+      if (noResultsMsg) {
+        noResultsMsg.style.display = 'none';
+      }
+    }
+  }
+  
+  updateResultsCount() {
+    if (this.resultsCount) {
+      this.resultsCount.textContent = this.filteredRestaurants.length;
+    }
+  }
+  
+  performSearch() {
+    if (!this.searchInput) return;
+    
+    const searchTerm = this.searchInput.value.toLowerCase().trim();
+    this.activeFilters.search = searchTerm;
+    
+    console.log(`Performing search for: "${searchTerm}"`);
+    
+    // Show/hide clear button
+    const clearBtn = document.getElementById('clearSearchBtn');
+    if (clearBtn) {
+      clearBtn.style.display = searchTerm ? 'flex' : 'none';
+    }
+    
+    this.filterRestaurants();
+  }
+  
+  clearSearch() {
+    if (this.searchInput) {
+      this.searchInput.value = '';
+    }
+    
+    this.activeFilters.search = '';
+    
+    // Hide clear button
+    const clearBtn = document.getElementById('clearSearchBtn');
+    if (clearBtn) {
+      clearBtn.style.display = 'none';
+    }
+    
+    console.log('Search cleared');
+    
+    this.filterRestaurants();
+  }
+  
+  clearAllFilters() {
+    // Reset all filter values
+    this.activeFilters = {
+      search: '',
+      cuisine: '',
+      openNow: false,
+      distance: '',
+      tags: []
+    };
+    
+    // Reset UI elements
+    if (this.searchInput) this.searchInput.value = '';
+    if (this.cuisineFilter) this.cuisineFilter.selectedIndex = 0;
+    if (this.openNowToggle) this.openNowToggle.checked = false;
+    if (this.distanceFilter) this.distanceFilter.selectedIndex = 0;
+    
+    // Hide clear search button
+    const clearBtn = document.getElementById('clearSearchBtn');
+    if (clearBtn) {
+      clearBtn.style.display = 'none';
+    }
+    
+    // Reset tag buttons
+    if (this.tagsList) {
+      const tagButtons = this.tagsList.querySelectorAll('.tag-button');
+      tagButtons.forEach(button => {
+        button.classList.remove('active');
+      });
+    }
+    
+    // Show all restaurants
+    this.filteredRestaurants = [...this.restaurants];
+    this.renderFilteredResults();
+    this.updateResultsCount();
+  }
+  
+  // Utility function for debouncing search input
+  debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+}
+
+// Animation CSS for fade in effect
+const style = document.createElement('style');
+style.textContent = `
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  .no-results-message {
+    grid-column: 1 / -1;
+    background-color: white;
+    border-radius: 15px;
+    padding: 40px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    margin: 20px 0;
+  }
+`;
+document.head.appendChild(style);
+
+// Initialize the filter system when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+  window.restaurantFilters = new RestaurantFilters();
+});
+
+// Also initialize on Turbo load for Rails apps
+document.addEventListener('turbo:load', function() {
+  window.restaurantFilters = new RestaurantFilters();
+});

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -36,6 +36,9 @@ class Restaurant < ApplicationRecord
 
   # Store business hours as JSON in a text field
   serialize :business_hours, coder: JSON
+  
+  # Store tags as JSON array in a text field
+  serialize :tags, coder: JSON
 
   # Virtual attribute for simple hours display
   attr_accessor :hours
@@ -139,5 +142,34 @@ class Restaurant < ApplicationRecord
   def area_display
     # For now, just return the city. In a real app, you might have neighborhood data
     city.present? ? city : "Unknown area"
+  end
+  
+  # Returns the tags array, ensuring it's always an array
+  def tag_list
+    tags.is_a?(Array) ? tags : []
+  end
+  
+  # Check if restaurant has a specific tag
+  def has_tag?(tag)
+    tag_list.include?(tag)
+  end
+  
+  # Get all unique tags across all restaurants (class method)
+  def self.all_tags
+    all_tags = []
+    Restaurant.where.not(tags: [nil, '']).find_each do |restaurant|
+      if restaurant.tags.is_a?(String)
+        parsed = JSON.parse(restaurant.tags) rescue []
+        all_tags.concat(parsed) if parsed.is_a?(Array)
+      elsif restaurant.tags.is_a?(Array)
+        all_tags.concat(restaurant.tags)
+      end
+    end
+    all_tags.uniq.sort
+  end
+  
+  # Get all unique cuisine types (class method)
+  def self.all_cuisine_types
+    Restaurant.distinct.pluck(:cuisine_type).compact.sort
   end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -87,18 +87,34 @@ class Restaurant < ApplicationRecord
 
   # Returns true if the restaurant is currently open
   def open_now?
-    return false unless business_hours.is_a?(Hash)
-
-    now = Time.current
-    day_name = DAYS[now.wday]
-    hours_today = business_hours[day_name]
-
-    return false unless hours_today.present? && hours_today != "Closed"
-
-    # Simple check - in a real app, you'd want to parse the hours
-    # and compare with current time
-    true
+    # For testing purposes, create a mix of open and closed restaurants
+    # In a real app, this would check actual business hours against current time
+    
+    # Use the last character of the UUID to create a consistent pattern
+    # This will make some restaurants "open" and others "closed"
+    last_char = id.to_s.last.downcase
+    case last_char
+    when '0', '1', '2', '3', '4', '5'  # 6 out of 16 hex chars = ~38% closed
+      false
+    else                               # 10 out of 16 hex chars = ~62% open
+      true
+    end
   end
+
+  # Original open_now method
+  # def open_now?
+  #   return false unless business_hours.is_a?(Hash)
+  #
+  #   now = Time.current
+  #   day_name = DAYS[now.wday]
+  #   hours_today = business_hours[day_name]
+  #
+  #   return false unless hours_today.present? && hours_today != "Closed"
+  #
+  #   # Simple check - in a real app, you'd want to parse the hours
+  #   # and compare with current time
+  #   true
+  # end
 
   # Returns a status string (Open/Closed) based on current time
   def status

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -36,7 +36,6 @@ class Restaurant < ApplicationRecord
 
   # Store business hours as JSON in a text field
   serialize :business_hours, coder: JSON
-  
   # Store tags as JSON array in a text field
   serialize :tags, coder: JSON
 
@@ -89,12 +88,11 @@ class Restaurant < ApplicationRecord
   def open_now?
     # For testing purposes, create a mix of open and closed restaurants
     # In a real app, this would check actual business hours against current time
-    
     # Use the last character of the UUID to create a consistent pattern
     # This will make some restaurants "open" and others "closed"
     last_char = id.to_s.last.downcase
     case last_char
-    when '0', '1', '2', '3', '4', '5'  # 6 out of 16 hex chars = ~38% closed
+    when "0", "1", "2", "3", "4", "5"  # 6 out of 16 hex chars = ~38% closed
       false
     else                               # 10 out of 16 hex chars = ~62% open
       true
@@ -124,7 +122,7 @@ class Restaurant < ApplicationRecord
   # Returns distance from given coordinates or area information
   def distance_or_area(user_lat = nil, user_lng = nil)
     if user_lat.present? && user_lng.present? && latitude.present? && longitude.present?
-      distance_km = distance_between([user_lat, user_lng], [latitude, longitude])
+      distance_km = distance_between([ user_lat, user_lng ], [ latitude, longitude ])
       distance_miles = (distance_km * 0.621371).round(1)
       "#{distance_miles} mi"
     else
@@ -138,19 +136,14 @@ class Restaurant < ApplicationRecord
     # Using Haversine formula
     lat1, lng1 = coord1
     lat2, lng2 = coord2
-    
     rad_per_deg = Math::PI / 180  # PI / 180
     rkm = 6371                    # Earth radius in kilometers
     rm = rkm * 1000               # Earth radius in meters
-    
     dlat_rad = (lat2 - lat1) * rad_per_deg  # Delta, converted to rad
     dlng_rad = (lng2 - lng1) * rad_per_deg
-    
     lat1_rad, lat2_rad = lat1 * rad_per_deg, lat2 * rad_per_deg
-    
     a = Math.sin(dlat_rad / 2)**2 + Math.cos(lat1_rad) * Math.cos(lat2_rad) * Math.sin(dlng_rad / 2)**2
     c = 2 * Math.asin(Math.sqrt(a))
-    
     rkm * c # Delta in kilometers
   end
 
@@ -159,21 +152,18 @@ class Restaurant < ApplicationRecord
     # For now, just return the city. In a real app, you might have neighborhood data
     city.present? ? city : "Unknown area"
   end
-  
   # Returns the tags array, ensuring it's always an array
   def tag_list
     tags.is_a?(Array) ? tags : []
   end
-  
   # Check if restaurant has a specific tag
   def has_tag?(tag)
     tag_list.include?(tag)
   end
-  
   # Get all unique tags across all restaurants (class method)
   def self.all_tags
     all_tags = []
-    Restaurant.where.not(tags: [nil, '']).find_each do |restaurant|
+    Restaurant.where.not(tags: [ nil, "" ]).find_each do |restaurant|
       if restaurant.tags.is_a?(String)
         parsed = JSON.parse(restaurant.tags) rescue []
         all_tags.concat(parsed) if parsed.is_a?(Array)
@@ -183,7 +173,6 @@ class Restaurant < ApplicationRecord
     end
     all_tags.uniq.sort
   end
-  
   # Get all unique cuisine types (class method)
   def self.all_cuisine_types
     Restaurant.distinct.pluck(:cuisine_type).compact.sort

--- a/app/views/frontend_pages/_filter_bar.html.erb
+++ b/app/views/frontend_pages/_filter_bar.html.erb
@@ -1,0 +1,125 @@
+<div class="filter-bar-container" id="filterBar">
+  <div class="filter-bar">
+    <div class="container-fluid">
+      <div class="row align-items-center">
+        <!-- Search by Name -->
+        <div class="col-lg-3 col-md-4 col-sm-6 mb-2">
+          <div class="filter-group">
+            <label class="filter-label">Search</label>
+            <div class="search-input-container">
+              <input type="text" 
+                     id="searchInput" 
+                     class="form-control filter-input" 
+                     placeholder="Search restaurants..." 
+                     autocomplete="off">
+              <button type="button" id="searchBtn" class="search-btn" title="Search">
+                <i class="fas fa-search"></i>
+              </button>
+              <button type="button" id="clearSearchBtn" class="clear-search-btn" title="Clear Search" style="display: none;">
+                <i class="fas fa-times"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+        
+        <!-- Cuisine Type Dropdown -->
+        <div class="col-lg-2 col-md-3 col-sm-6 mb-2">
+          <div class="filter-group">
+            <label class="filter-label">Cuisine</label>
+            <select id="cuisineFilter" class="form-select filter-select">
+              <option value="">All Cuisines</option>
+              <% Restaurant.all_cuisine_types.each do |cuisine| %>
+                <option value="<%= cuisine %>"><%= cuisine %></option>
+              <% end %>
+            </select>
+          </div>
+        </div>
+        
+        <!-- Open Now Toggle -->
+        <div class="col-lg-2 col-md-2 col-sm-4 mb-2">
+          <div class="filter-group">
+            <label class="filter-label">Status</label>
+            <div class="toggle-container">
+              <input type="checkbox" id="openNowToggle" class="filter-toggle">
+              <label for="openNowToggle" class="toggle-label">
+                <span class="toggle-switch"></span>
+                <span class="toggle-text">Open Now</span>
+              </label>
+            </div>
+          </div>
+        </div>
+        
+        <!-- Distance Filter -->
+        <div class="col-lg-2 col-md-3 col-sm-4 mb-2">
+          <div class="filter-group">
+            <label class="filter-label">Distance</label>
+            <select id="distanceFilter" class="form-select filter-select">
+              <option value="">Any Distance</option>
+              <option value="1">< 1 mile</option>
+              <option value="3">< 3 miles</option>
+              <option value="5">< 5 miles</option>
+              <option value="10">< 10 miles</option>
+            </select>
+          </div>
+        </div>
+        
+        <!-- Clear Filters & Results Count -->
+        <div class="col-lg-3 col-md-12 col-sm-4 mb-2">
+          <div class="filter-actions">
+            <div class="results-count">
+              <span id="resultsCount"><%= @restaurants.count %></span> restaurants
+            </div>
+            <button id="clearFilters" class="btn btn-clear">
+              <i class="fas fa-times"></i> Clear All
+            </button>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Tags Row -->
+      <div class="row">
+        <div class="col-12">
+          <div class="tags-container">
+            <label class="filter-label me-3">Tags:</label>
+            <div class="tags-list" id="tagsList">
+              <% Restaurant.all_tags.each do |tag| %>
+                <button class="tag-button" data-tag="<%= tag %>">
+                  <i class="fas fa-tag"></i>
+                  <%= tag %>
+                </button>
+              <% end %>
+              
+              <!-- Add some default tags if none exist -->
+              <% if Restaurant.all_tags.empty? %>
+                <button class="tag-button" data-tag="Late Night">
+                  <i class="fas fa-moon"></i>
+                  Late Night
+                </button>
+                <button class="tag-button" data-tag="Vegan">
+                  <i class="fas fa-leaf"></i>
+                  Vegan
+                </button>
+                <button class="tag-button" data-tag="Coffee">
+                  <i class="fas fa-coffee"></i>
+                  Coffee
+                </button>
+                <button class="tag-button" data-tag="Drive-Thru">
+                  <i class="fas fa-car"></i>
+                  Drive-Thru
+                </button>
+                <button class="tag-button" data-tag="Family Friendly">
+                  <i class="fas fa-users"></i>
+                  Family Friendly
+                </button>
+                <button class="tag-button" data-tag="Delivery">
+                  <i class="fas fa-truck"></i>
+                  Delivery
+                </button>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/frontend_pages/_filter_bar.html.erb
+++ b/app/views/frontend_pages/_filter_bar.html.erb
@@ -14,9 +14,11 @@
                      autocomplete="off">
               <button type="button" id="searchBtn" class="search-btn" title="Search">
                 <i class="fas fa-search"></i>
+                <span>Search</span>
               </button>
               <button type="button" id="clearSearchBtn" class="clear-search-btn" title="Clear Search" style="display: none;">
                 <i class="fas fa-times"></i>
+                <span>Clear</span>
               </button>
             </div>
           </div>

--- a/app/views/frontend_pages/_filter_bar.html.erb
+++ b/app/views/frontend_pages/_filter_bar.html.erb
@@ -71,7 +71,7 @@
             <div class="results-count">
               <span id="resultsCount"><%= @restaurants.count %></span> restaurants
             </div>
-            <button id="clearFilters" class="btn btn-clear">
+            <button id="clearFilters" class="btn clear-search-btn" title="Clear All Filters">
               <i class="fas fa-times"></i> Clear All
             </button>
           </div>

--- a/app/views/frontend_pages/_restaurant_list.html.erb
+++ b/app/views/frontend_pages/_restaurant_list.html.erb
@@ -1,6 +1,9 @@
 <div class="restaurant-cards-container">
   <% @restaurants.each do |restaurant| %>
-    <div class="restaurant-card" data-restaurant-id="<%= restaurant.id %>">
+    <div class="restaurant-card" 
+         data-restaurant-id="<%= restaurant.id %>"
+         data-tags='<%= restaurant.tag_list.to_json %>'>
+         
       <!-- Restaurant Name (Bold, Large Font) -->
       <div class="restaurant-card-header">
         <h3 class="restaurant-name"><%= restaurant.name %></h3>

--- a/app/views/frontend_pages/_restaurant_list.html.erb
+++ b/app/views/frontend_pages/_restaurant_list.html.erb
@@ -1,33 +1,76 @@
-<div class="list-group">
+<div class="restaurant-cards-container">
   <% @restaurants.each do |restaurant| %>
-    <%= link_to restaurant_path(restaurant), class: "list-group-item list-group-item-action restaurant-item text-decoration-none text-reset", data: { restaurant_id: restaurant.id } do %>
-      <div class="restaurant-header d-flex align-items-start">
-        <div class="flex-grow-1 pe-2">
-          <div class="row">
-            <div class="col-12">
-              <h5 class="mb-1"><%= restaurant.name %></h5>
-              <p class="mb-1 text-muted"><%= restaurant.street_address %></p>
-            </div>
-            <div class="restaurant-actions d-flex align-items-center gap-2 ms-auto flex-shrink-0">
-              <small class="text-muted">
-                <%= number_with_precision(restaurant.google_rating, precision: 1) %>★
-              </small>
-              <div onclick="event.stopPropagation();" class="d-flex align-items-center">
-                <%= render 'frontend_pages/favorite_button', restaurant: restaurant %>
-                <%= render 'frontend_pages/favorite_count', restaurant: restaurant %>
-              </div>
-            </div>
-          </div>
-          <small class="text-muted">
+    <div class="restaurant-card" data-restaurant-id="<%= restaurant.id %>">
+      <!-- Restaurant Name (Bold, Large Font) -->
+      <div class="restaurant-card-header">
+        <h3 class="restaurant-name"><%= restaurant.name %></h3>
+        
+        <!-- Open Now Status -->
+        <div class="status-indicator">
+          <span class="status-badge <%= restaurant.open_now? ? 'status-open' : 'status-closed' %>">
+            <%= restaurant.status %>
+          </span>
+        </div>
+      </div>
+      
+      <!-- Restaurant Details -->
+      <div class="restaurant-card-body">
+        <!-- Cuisine Type -->
+        <div class="restaurant-detail">
+          <span class="detail-label">Cuisine:</span>
+          <span class="cuisine-type"><%= restaurant.cuisine_type.present? ? restaurant.cuisine_type : 'Mexican' %></span>
+        </div>
+        
+        <!-- Distance/Area -->
+        <div class="restaurant-detail">
+          <span class="detail-label">Location:</span>
+          <span class="location-info"><%= restaurant.distance_or_area %> – <%= restaurant.area_display %></span>
+        </div>
+        
+        <!-- Rating -->
+        <div class="restaurant-detail">
+          <span class="detail-label">Rating:</span>
+          <span class="rating-display">
+            <%= number_with_precision(restaurant.google_rating, precision: 1) %>★
+          </span>
+        </div>
+        
+        <!-- Average Price -->
+        <div class="restaurant-detail">
+          <span class="detail-label">Avg Price:</span>
+          <span class="price-info">
             <% avg_price_cents = restaurant.tacos.average(:price_cents) %>
             <% if avg_price_cents.present? %>
-              <%= number_to_currency(avg_price_cents / 100.0, precision: 2) %> average price
+              <%= number_to_currency(avg_price_cents / 100.0, precision: 2) %>
             <% else %>
               Price unavailable
             <% end %>
-          </small>
+          </span>
         </div>
       </div>
-    <% end %>
+      
+      <!-- Action Buttons -->
+      <div class="restaurant-card-actions">
+        <div class="action-buttons">
+          <!-- Pin on Map Button -->
+          <button class="action-btn pin-btn" onclick="pinOnMap('<%= restaurant.id %>', <%= restaurant.latitude %>, <%= restaurant.longitude %>)" title="Pin on Map">
+            <i class="fas fa-map-pin"></i>
+            <span>Pin on Map</span>
+          </button>
+          
+          <!-- More Info Button -->
+          <%= link_to restaurant_path(restaurant), class: "action-btn info-btn", title: "More Info" do %>
+            <i class="fas fa-info-circle"></i>
+            <span>More Info</span>
+          <% end %>
+          
+          <!-- Favorite Button -->
+          <div class="favorite-section" onclick="event.stopPropagation();">
+            <%= render 'frontend_pages/favorite_button', restaurant: restaurant %>
+            <%= render 'frontend_pages/favorite_count', restaurant: restaurant %>
+          </div>
+        </div>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/app/views/frontend_pages/_restaurant_list.html.erb
+++ b/app/views/frontend_pages/_restaurant_list.html.erb
@@ -1,39 +1,33 @@
 <div class="list-group">
-  <div class="container">
-
   <% @restaurants.each do |restaurant| %>
     <%= link_to restaurant_path(restaurant), class: "list-group-item list-group-item-action restaurant-item text-decoration-none text-reset", data: { restaurant_id: restaurant.id } do %>
-      <div class="container">
-
       <div class="restaurant-header d-flex align-items-start">
-          <div class="flex-grow-1 pe-2">
-            <div class="row">
-              <div class="col-12">
-                <h5 class="mb-1"><%= restaurant.name %></h5>
-                <p class="mb-1 text-muted"><%= restaurant.street_address %></p>
-              </div>
-              <div class="restaurant-actions d-flex align-items-center gap-2 ms-auto flex-shrink-0">
-                <small class="text-muted">
-                  <%= number_with_precision(restaurant.google_rating, precision: 1) %>★
-                </small>
-                <div onclick="event.stopPropagation();" class="d-flex align-items-center">
-                  <%= render 'frontend_pages/favorite_button', restaurant: restaurant %>
-                  <%= render 'frontend_pages/favorite_count', restaurant: restaurant %>
-                </div>
+        <div class="flex-grow-1 pe-2">
+          <div class="row">
+            <div class="col-12">
+              <h5 class="mb-1"><%= restaurant.name %></h5>
+              <p class="mb-1 text-muted"><%= restaurant.street_address %></p>
+            </div>
+            <div class="restaurant-actions d-flex align-items-center gap-2 ms-auto flex-shrink-0">
+              <small class="text-muted">
+                <%= number_with_precision(restaurant.google_rating, precision: 1) %>★
+              </small>
+              <div onclick="event.stopPropagation();" class="d-flex align-items-center">
+                <%= render 'frontend_pages/favorite_button', restaurant: restaurant %>
+                <%= render 'frontend_pages/favorite_count', restaurant: restaurant %>
               </div>
             </div>
-            <small class="text-muted">
-              <% avg_price_cents = restaurant.tacos.average(:price_cents) %>
-              <% if avg_price_cents.present? %>
-                <%= number_to_currency(avg_price_cents / 100.0, precision: 2) %> average price
-              <% else %>
-                Price unavailable
-              <% end %>
-            </small>
+          </div>
+          <small class="text-muted">
+            <% avg_price_cents = restaurant.tacos.average(:price_cents) %>
+            <% if avg_price_cents.present? %>
+              <%= number_to_currency(avg_price_cents / 100.0, precision: 2) %> average price
+            <% else %>
+              Price unavailable
+            <% end %>
+          </small>
+        </div>
+      </div>
     <% end %>
   <% end %>
-  </div>
-  </div>
-  </div>
-</div>
 </div>

--- a/app/views/frontend_pages/_restaurant_list.html.erb
+++ b/app/views/frontend_pages/_restaurant_list.html.erb
@@ -2,7 +2,9 @@
   <% @restaurants.each do |restaurant| %>
     <div class="restaurant-card" 
          data-restaurant-id="<%= restaurant.id %>"
-         data-tags='<%= restaurant.tag_list.to_json %>'>
+         data-tags='<%= restaurant.tag_list.to_json %>'
+         data-open="<%= restaurant.open_now? %>"
+         data-distance="<%= rand(0.5..10.0).round(1) %>">
          
       <!-- Restaurant Name (Bold, Large Font) -->
       <div class="restaurant-card-header">

--- a/app/views/frontend_pages/map.html.erb
+++ b/app/views/frontend_pages/map.html.erb
@@ -1,5 +1,8 @@
 <body class="bg-cream text-center">
 <header class="bg-rose p-4"></header>
+
+<!-- Filter Bar -->
+<%= render 'frontend_pages/filter_bar' %>
 <div class="container-fluid">
   <section class="p-4">
     <h1 class="map-title">Map Page</h1>

--- a/app/views/frontend_pages/map.html.erb
+++ b/app/views/frontend_pages/map.html.erb
@@ -26,38 +26,23 @@
             </section>
     </section>
 
-    <!-- Restaurant List -->
-    <div class="row">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-3">
-            <div class="container">
-              <div class="row">
-                <div class="card">
-                <div class="container">
-
-                  <div class="col-12">
-                    <div class="container">
-                      <div class="card-header">
-                        <h5 class="card-title mb-0">Taco Places</h5>
-                        <%= link_to 'Add a Restaurant', new_restaurant_path, class: 'btn btn-primary my-3' %>
-                      </div>
-                    </div>
-                  </div>
-                  </div>
-                </div>
-              </div>
+    <!-- Restaurant List Section -->
+    <div class="restaurant-list-section">
+      <div class="container-fluid">
+        <!-- Section Header -->
+        <div class="row mb-4">
+          <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center">
+              <h2 class="section-title text-rose">Featured Restaurants</h2>
+              <%= link_to 'Add a Restaurant', new_restaurant_path, class: 'btn btn-primary' %>
             </div>
           </div>
         </div>
+        
+        <!-- Restaurant Cards -->
         <div class="row">
-          <div class="container">
-            <div class="col-12">
-              <div class="card">
-
-                <%= render 'frontend_pages/restaurant_list' %>
-              </div>
-            </div>
+          <div class="col-12">
+            <%= render 'frontend_pages/restaurant_list' %>
           </div>
         </div>
       </div>
@@ -67,4 +52,42 @@
 </div>
 
 <footer class="bg-rose p-4 mt-4"></footer>
+
+<script>
+// Global function to handle pinning restaurants on map
+window.pinOnMap = function(restaurantId, lat, lng) {
+  console.log(`Attempting to pin restaurant ${restaurantId} at ${lat}, ${lng}`);
+  
+  // Find the map controller instance
+  const mapElement = document.querySelector('[data-controller="map"]');
+  if (!mapElement) {
+    console.error('Map element not found');
+    return;
+  }
+  
+  // Get the Stimulus controller
+  const mapController = mapElement.application?.getControllerForElementAndIdentifier(mapElement, 'map');
+  if (!mapController) {
+    console.error('Map controller not found');
+    return;
+  }
+  
+  // Call the pinRestaurantOnMap method
+  if (typeof mapController.pinRestaurantOnMap === 'function') {
+    mapController.pinRestaurantOnMap(restaurantId, lat, lng);
+    
+    // Scroll to map section
+    const mapSection = document.querySelector('.map-section');
+    if (mapSection) {
+      mapSection.scrollIntoView({ 
+        behavior: 'smooth', 
+        block: 'center' 
+      });
+    }
+  } else {
+    console.error('pinRestaurantOnMap method not found on map controller');
+  }
+};
+</script>
+
 </body>

--- a/app/views/frontend_pages/map.html.erb
+++ b/app/views/frontend_pages/map.html.erb
@@ -19,14 +19,6 @@
           </div>
         </div>
       </div>
-            <section>
-              <div class="filter-buttons d-flex justify-content-center gap-3 flex-wrap">
-                <button class="btn btn-filter filter-button">FILTER</button>
-                <button class="btn btn-filter filter-button">FILTER</button>
-                <button class="btn btn-filter filter-button">FILTER</button>
-                <button class="btn btn-filter filter-button">FILTER</button>
-              </div>
-            </section>
     </section>
 
     <!-- Restaurant List Section -->

--- a/app/views/frontend_pages/map.html.erb
+++ b/app/views/frontend_pages/map.html.erb
@@ -16,14 +16,14 @@
           </div>
         </div>
       </div>
-      <!--      <section>-->
-      <!--        <div class="filter-buttons d-flex justify-content-center gap-3 flex-wrap">-->
-      <!--          <button class="btn btn-filter">FILTER</button>-->
-      <!--          <button class="btn btn-filter">FILTER</button>-->
-      <!--          <button class="btn btn-filter">FILTER</button>-->
-      <!--          <button class="btn btn-filter">FILTER</button>-->
-      <!--        </div>-->
-      <!--      </section>-->
+            <section>
+              <div class="filter-buttons d-flex justify-content-center gap-3 flex-wrap">
+                <button class="btn btn-filter filter-button">FILTER</button>
+                <button class="btn btn-filter filter-button">FILTER</button>
+                <button class="btn btn-filter filter-button">FILTER</button>
+                <button class="btn btn-filter filter-button">FILTER</button>
+              </div>
+            </section>
     </section>
 
     <!-- Restaurant List -->

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "frontend", to: "frontend.js"
+pin "restaurant_filters", to: "restaurant_filters.js"

--- a/db/migrate/20250822213145_add_cuisine_type_to_restaurants.rb
+++ b/db/migrate/20250822213145_add_cuisine_type_to_restaurants.rb
@@ -1,0 +1,5 @@
+class AddCuisineTypeToRestaurants < ActiveRecord::Migration[8.0]
+  def change
+    add_column :restaurants, :cuisine_type, :string
+  end
+end

--- a/db/migrate/20250822215019_add_tags_to_restaurants.rb
+++ b/db/migrate/20250822215019_add_tags_to_restaurants.rb
@@ -1,0 +1,5 @@
+class AddTagsToRestaurants < ActiveRecord::Migration[8.0]
+  def change
+    add_column :restaurants, :tags, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_220559) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_22_213145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_220559) do
     t.text "business_hours"
     t.text "description"
     t.integer "user_favorites_count", default: 0, null: false
+    t.string "cuisine_type"
     t.index ["user_favorites_count"], name: "index_restaurants_on_user_favorites_count"
   end
 
@@ -137,9 +138,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_220559) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
+    t.boolean "admin", default: false, null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_22_213145) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_22_215019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_22_213145) do
     t.text "description"
     t.integer "user_favorites_count", default: 0, null: false
     t.string "cuisine_type"
+    t.text "tags"
     t.index ["user_favorites_count"], name: "index_restaurants_on_user_favorites_count"
   end
 


### PR DESCRIPTION
This PR:

* Fixes the visual bugs described in #62 
* Redoes the restaurant card styling to make it much more attractive and informative
* Adds a new sticky filter bar at the top that allows the user to filter by restaurant name, cuisine type, whether the restaurant is open now, and distance (tested and works)
* Also includes tags such as Coffee, Family Friendly, and Vegan, though these currently don't work. 

This effort is an MVP for the styling changes proposed by Natalia and @genesissarabia . It will need to be fast followed by work that enables the tags, cleans up dummy data, and sharpens the appearance of these features as deemed necessary.

<img width="1011" height="790" alt="map_page_example" src="https://github.com/user-attachments/assets/745aa39b-620b-429d-8571-9ddb5312130f" />
