### PR TITLE
Remove broken validates call

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, length: { minimum: 6 }, if: -> { new_record? || !password.blank? }
-  validates :username, uniqueness: true, length: { minimum: 3, maximum: 20 }, allow_blank: true
 
   def favorite?(restaurant)
     return false if restaurant.nil?


### PR DESCRIPTION
As far as I can see, there is no username field on users.

There is also a lot of code that checks if a user responds to `:username` but I don't see anything that creates a username.

I didn't see it in the migrations.

I verified this by checking that the seeds run after removing this line.  They failed before.